### PR TITLE
docs: プログラミング言語インストール詳細を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@
 - Firefox、Brave、Arc（Chrome、Safariは既にインストール済み）
 
 #### プログラミング言語
-- Node.js, Python, Go, Rust, Ruby, Java, PHP, Kotlin, Swift
+- Node.js（nvm, yarn, pnpm含む）
+- Python（pyenv, pipenv, pipx含む）
+- Go, Rust, Ruby, Java, PHP, Kotlin, Swift
 
 #### データベース
 - PostgreSQL, MySQL, Redis, MongoDB, SQLite, Elasticsearch, Cassandra, Neo4j

--- a/mac-setup-modular.sh
+++ b/mac-setup-modular.sh
@@ -299,7 +299,7 @@ install_programming_languages() {
                 brew install nvm node yarn pnpm
                 ;;
             1) # Python
-                brew install python@3.12 pyenv pipenv
+                brew install python@3.12 pyenv pipenv pipx
                 ;;
             2) # Go
                 brew install go


### PR DESCRIPTION
## Summary
- README.mdにNode.jsとPythonのインストール詳細を追加
- mac-setup-modular.shにPythonパッケージ管理用のpipxツールを追加

## Test plan
- [ ] スクリプトの実行に問題がないことを確認
- [ ] 新しいツールのインストールが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)