### PR TITLE
feat: pipxとzoxide設定の改善

### DIFF
--- a/mac-setup-modular.sh
+++ b/mac-setup-modular.sh
@@ -559,7 +559,7 @@ alias du='dust'
 alias df='duf'
 alias ps='procs'
 alias top='btm'
-alias cd='z'
+# Remove cd alias - zoxide will handle it via eval
 
 # Basic aliases
 alias l='ls -CF'


### PR DESCRIPTION
## Summary
- pipxインストール後に`pipx ensurepath`を自動実行し、パス設定を確実に行うよう改善
- zoxideのcd aliasを削除し、eval経由での正しい初期化に変更
- メニューバー時計設定に秒表示とコロン点滅機能を追加

## Test plan
- [ ] 新規Mac環境でスクリプトを実行し、pipxがパスに正しく設定されることを確認
- [ ] zoxideインストール後、cdコマンドが正常に動作することを確認
- [ ] メニューバーの時計設定が適用されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)