### PR TITLE
feat: Mac開発環境セットアップの機能拡張とMinicondaサポート

### DIFF
--- a/mac-setup-modular.sh
+++ b/mac-setup-modular.sh
@@ -346,6 +346,8 @@ install_programming_languages() {
                 ;;
             2) # Python (Miniconda)
                 setup_miniconda
+                brew install pipenv pipx
+                pipx ensurepath
                 ;;
             3) # Go
                 brew install go


### PR DESCRIPTION
## Summary
- Minicondaインストールオプションを追加（pipenv/pipxサポート付き）
- Python 3.12をデフォルトバージョンとして設定する機能
- エンターテイメントカテゴリの追加
- スペック駆動開発システムのドキュメント整備
- 各種バグ修正と改善

## 主な変更点

### 新機能
- **Minicondaサポート**: 
  - brewによるMinicondaインストール
  - pyenvとの競合チェックと共存ガイダンス
  - pipenv/pipxの同時インストール
- **Python 3.12デフォルト設定**: pyenvまたはHomebrewのPython 3.12を自動設定
- **エンターテイメントカテゴリ**: Steam、Discord、Spotify、VLCなどのセットアップ

### 改善
- zoxideのcd aliasバグを修正
- pipx ensurepathの自動実行
- macOS設定にメニューバー時計の詳細オプション追加

### ドキュメント
- spec/ディレクトリに包括的な仕様書を追加
- 各機能モジュールごとの要件・設計・タスクドキュメント
- CLAUDE.mdにスペック駆動開発システムのガイドライン

## Test plan
- [ ] 新規Macでのフルセットアップテスト
- [ ] Minicondaインストールと設定の動作確認
- [ ] pyenvとMinicondaの共存確認
- [ ] Python 3.12設定機能の動作確認
- [ ] エンターテイメントカテゴリのインストール確認

🤖 Generated with [Claude Code](https://claude.ai/code)