### PR TITLE
feat: Python開発環境の改善とCLIエイリアスの最適化

### DIFF
--- a/mac-setup-modular.sh
+++ b/mac-setup-modular.sh
@@ -764,7 +764,7 @@ alias ll='eza -l --icons --git'
 alias la='eza -la --icons --git'
 alias lt='eza --tree --level=2'
 alias find='fd'
-alias grep='rg'
+# alias grep='rg'  # grepエイリアスは無効化
 alias du='dust'
 alias df='duf'
 alias ps='procs'


### PR DESCRIPTION
## Summary
- Python 3.12をデフォルトバージョンとして設定する機能を追加
- Minicondaインストールオプションとpipenv/pipxサポートを追加
- grepエイリアスを無効化して標準コマンドとの互換性を保持

## 主な変更点

### Python開発環境の強化
- **Python 3.12のデフォルト設定**: pyenvまたはHomebrewのPythonを使用してPython 3.12をデフォルトに設定
- **Minicondaサポート**: データサイエンス向けにMinicondaインストールオプションを追加
- **pipenvとpipx**: 仮想環境管理とグローバルツールインストールのサポートを追加

### CLIツールの改善
- **grepエイリアスの無効化**: 標準grepコマンドとの互換性を保つため、ripgrepへのエイリアスを無効化
- **zoxideの修正**: cdエイリアスを削除し、eval経由で正しく動作するよう修正

### その他の改善
- メニューバー時計に秒表示とコロン点滅を追加
- エンターテイメントカテゴリを追加（VLC、Spotify、IINA等）
- スペック駆動開発システムのドキュメントを追加
- settings.jsonによる通知設定の追加

## Test plan
- [x] Python 3.12のインストールとデフォルト設定の動作確認
- [x] Minicondaのインストールと初期設定の動作確認
- [x] pipenvとpipxのインストールとパス設定の確認
- [x] grepコマンドが標準のまま動作することを確認
- [x] 各種CLIツールのエイリアスが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)